### PR TITLE
Fix esbuild url for arm64

### DIFF
--- a/esbuild_repo.bzl
+++ b/esbuild_repo.bzl
@@ -44,7 +44,7 @@ def esbuild_dependencies():
     http_archive(
         name = "esbuild_linux_arm64",
         urls = [
-            "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-arm64-%s.tgz" % version,
+            "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-%s.tgz" % version,
         ],
         strip_prefix = "package",
         build_file_content = """exports_files(["bin/esbuild"])""",


### PR DESCRIPTION
esbuild url for arm64 is invalid. This patch fixes it. The python script already points to correct url